### PR TITLE
Option to remove form aria attributes

### DIFF
--- a/src/Search.svelte
+++ b/src/Search.svelte
@@ -11,6 +11,7 @@
   export let hideLabel = false;
   export let id = "search" + Math.random().toString(36);
   export let ref = null;
+  export let removeFormAriaAttributes = false;
 
   import { createEventDispatcher, onMount, afterUpdate } from "svelte";
 
@@ -65,7 +66,7 @@
   }
 </style>
 
-<form data-svelte-search role="search" aria-labelledby={id} on:submit|preventDefault>
+<form data-svelte-search role={removeFormAriaAttributes ? null : "search"} aria-labelledby={removeFormAriaAttributes ? null : id} on:submit|preventDefault>
   <label id="{id}-label" for={id} class:hide-label={hideLabel}>
     <slot name="label">{label}</slot>
   </label>

--- a/types/Search.d.ts
+++ b/types/Search.d.ts
@@ -36,6 +36,11 @@ export interface SearchProps extends svelte.JSX.HTMLAttributes<HTMLElementTagNam
    * @default null
    */
   ref?: null | HTMLInputElement;
+  
+  /**
+   * @default false
+   */
+  removeFormAriaAttributes ?: boolean;
 }
 
 export default class Search extends SvelteComponentTyped<


### PR DESCRIPTION
metonym/svelte-typeahead#19 did not solve the Lighthouse issues, but removing the `role` and `aria-labelledby` from the form does (Typeahead's `[data-svelte-typeahead]` wrapper should hopefully retain all the accessibility properties). 
If the PR is accepted, Typeahead will need to be updated use this non-default option.