### PR TITLE
Make valid ES module

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "module": "./src/index.js",
   "types": "./types/index.d.ts",
   "sideEffects": false,
+  "type": "module",
   "scripts": {
     "dev": "rollup -cw",
     "predeploy": "rollup -c",


### PR DESCRIPTION
Hello @metonym ! Thank you for writing this library !

I've got a warning from Node.js when using it:

```sh
svelte-search doesn't appear to be written in CJS, but also doesn't appear to be a valid ES module (i.e. it doesn't have "type": "module" or an .mjs extension for the entry point). Please contact the package author to fix.
```

I think it's the only change needed for fixing it.