### PR TITLE
Enables the "Search" button on iOS keyboards, which then can be customised with the `enterkeyhint` attribute

### DIFF
--- a/src/Search.svelte
+++ b/src/Search.svelte
@@ -82,6 +82,7 @@
   data-svelte-search
   role={removeFormAriaAttributes ? null : "search"}
   aria-labelledby={removeFormAriaAttributes ? null : id}
+  action=""
   on:submit|preventDefault
 >
   <label


### PR DESCRIPTION
Putting this attribute on the wrapping `<form>` makes the on-screen keyboard in iOS use the blue "Search" button. Then we can pass through the [`enterkeyhint`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/enterkeyhint) to change the label. 