### PR TITLE
fix(search): fix clearing search when debounced

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ Bind the `ref` prop to programmatically focus the input.
 
 Use the `debounce` prop to specify the debounce value in milliseconds.
 
+If clearing the value, both the `on:type` and `on:clear` events will immediately be dispatched.
+
 ```svelte
 <script>
   import Search from "svelte-search";

--- a/src/Search.svelte
+++ b/src/Search.svelte
@@ -64,15 +64,19 @@
   });
 
   afterUpdate(() => {
-    if (value.length > 0 && value !== prevValue) {
-      if (debounce > 0) {
+    if (value !== prevValue) {
+      // If clearing (going from text to empty), dispatch immediately.
+      if (prevValue.length > 0 && value.length === 0) {
+        dispatch("type", value);
+        dispatch("clear");
+      } else if (debounce > 0) {
+        // For typing/changes, use debounce.
         debounceFn(() => dispatch("type", value));
       } else {
+        // No debounce, dispatch immediately.
         dispatch("type", value);
       }
     }
-
-    if (value.length === 0 && prevValue.length > 0) dispatch("clear");
 
     prevValue = value;
   });


### PR DESCRIPTION
Fixes #17

Currently, if you select all text and hit Delete, `on:type` isn't fired. In the initial implementation, this was intentional (and hence why `on:clear` existed. However, in hindsight, I've reversed course on this. It's both natural and good DX to expect `on:type` to fire on any value change.

This fix updates the behavior so that, if selecting all text and deleting, `on:type` and `on:clear` will fire immediately. This is also good UX since the transition to the empty value should not be debounced.